### PR TITLE
Remove dependency on mqtt_broker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,6 @@ services:
                 options:
                     tag: docker-timeseries-db
             restart: unless-stopped
-            depends_on:
-                - "mqtt_broker"
             
         timeseries-db-input:
             image: telegraf:1.21
@@ -47,4 +45,3 @@ services:
             restart: unless-stopped
             depends_on:
                 - "timeseries-db"
-                - "mqtt_broker"


### PR DESCRIPTION
If our Service Modules are indeed modular, Solutions should be able to select their modules as freely as possible.
Whilst there will inevitably be some modules that don't work without certain others, I don't see any reason why this Influx/Telegraf SM should depend on the MQTT Broker. The broker could be on another device, Telegraf could be configured to find it.

This may impact docker-compose startup - services may not be brought up in the ideal order - but I feel that is acceptable.

The internal dependency of telegraf on influx however is appropriate. 